### PR TITLE
Adapt Maneuver to work with Laravel 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.2.*",
-        "illuminate/console": "4.2.*",
-        "illuminate/config": "4.2.*",
-        "banago/bridge": "~1.0.6",
+        "illuminate/support": "5.0.*",
+        "illuminate/console": "5.0.*",
+        "illuminate/config": "5.0.*",
+        "banago/bridge": "~1.0.8",
         "jakeasmith/http_build_url": "~0.1.2"
     },
     "autoload": {

--- a/src/Fadion/Maneuver/Connection.php
+++ b/src/Fadion/Maneuver/Connection.php
@@ -26,8 +26,8 @@ class Connection {
     public function __construct($server = null)
     {
         // Load connections array from config.
-        $connections = app()->config['maneuver::config.connections'];
-        $default = app()->config['maneuver::config.default'];
+        $connections = config('maneuver.connections');
+        $default = config('maneuver.default');
 
         if (!$connections) {
             throw new Exception("Connections list not set or empty. Please fill it with servers in Maneuver's config.");

--- a/src/Fadion/Maneuver/ManeuverServiceProvider.php
+++ b/src/Fadion/Maneuver/ManeuverServiceProvider.php
@@ -23,7 +23,9 @@ class ManeuverServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->package('fadion/maneuver');
+        $this->publishes([
+            __DIR__ . '/../../config/config.php' => config_path('maneuver.php')
+        ]);
     }
 
 	/**


### PR DESCRIPTION
The ServiceProvider interface underwent several changes in the new Laravel 5 release.
This fork provides all the changes necessary to work with this latest version of the PHP Web-Framework.